### PR TITLE
Add denial context and proces new device response to support it.

### DIFF
--- a/src/iovation.LaunchKey.Sdk.ExampleCli/ClientFactories.cs
+++ b/src/iovation.LaunchKey.Sdk.ExampleCli/ClientFactories.cs
@@ -11,7 +11,7 @@ namespace iovation.LaunchKey.Sdk.ExampleCli
 			var factoryFactoryBuilder = new FactoryFactoryBuilder();
 			if (apiURL != null)
 			{
-				factoryFactoryBuilder.SetApiBaseUrl(apiURL);
+				factoryFactoryBuilder.SetApiBaseUrl(apiURL).SetOffsetTtl(60);
 			}
 			var factory = factoryFactoryBuilder.Build();
 			return factory;

--- a/src/iovation.LaunchKey.Sdk.ExampleCli/Program.cs
+++ b/src/iovation.LaunchKey.Sdk.ExampleCli/Program.cs
@@ -26,8 +26,8 @@ namespace iovation.LaunchKey.Sdk.ExampleCli
 					OrgServiceAuthOptions>(args)
 				.MapResult(
 					// service functions
-					(ServiceAuthOptions opts) => ServiceExamples.DoServiceAuthorization(opts.Username, opts.ServiceId, opts.PrivateKeyPath, opts.APIURL),
-					(ServiceAuthWebhookOptions opts) => ServiceExamples.DoServiceAuthorizationWebhook(opts.Username, opts.ServiceId, opts.PrivateKeyPath, opts.APIURL),
+					(ServiceAuthOptions opts) => ServiceExamples.DoServiceAuthorization(opts.Username, opts.ServiceId, opts.PrivateKeyPath, opts.APIURL, opts.Context, opts.TTL, opts.AuthTitle, opts.PushTitle, opts.PushBody, opts.FraudDenialReasons, opts.NonFraudDenialReasons),
+					(ServiceAuthWebhookOptions opts) => ServiceExamples.DoServiceAuthorizationWebhook(opts.Username, opts.ServiceId, opts.PrivateKeyPath, opts.APIURL, opts.Context, opts.TTL, opts.AuthTitle, opts.PushTitle, opts.PushBody, opts.FraudDenialReasons, opts.NonFraudDenialReasons),
 					(ServiceAuthWithPolicy opts) => ServiceExamples.DoServiceAuthorizationWithPolicy(opts.Username, opts.ServiceId, opts.PrivateKeyPath, opts.JailbreakDetection, opts.Factors, opts.Geofence, opts.APIURL),
 					(ServiceSessionStartOptions opts) => ServiceExamples.DoSessionStart(opts.Username, opts.ServiceId, opts.PrivateKeyPath, opts.APIURL),
 					(ServiceSessionEndOptions opts) => ServiceExamples.DoSessionEnd(opts.Username, opts.ServiceId, opts.PrivateKeyPath, opts.APIURL),

--- a/src/iovation.LaunchKey.Sdk.ExampleCli/ProgramOptions.cs
+++ b/src/iovation.LaunchKey.Sdk.ExampleCli/ProgramOptions.cs
@@ -148,18 +148,43 @@ namespace iovation.LaunchKey.Sdk.ExampleCli
 		public string Username { get; set; }
 	}
 
-	[Verb("service-auth", HelpText = "Authorize a user against a service using a polling method")]
-	class ServiceAuthOptions : ServiceOptions
-	{
+	class AuthOptions : ServiceOptions
+	{ 
 		[Option('u', "username", HelpText = "The username to authorize", Required = true)]
 		public string Username { get; set; }
+
+		[Option('c', "context", HelpText = "The context value of the authorizaton request.")]
+		public string Context { get; set; }
+
+		[Option('l', "ttl", HelpText = "[Directory Service Only] Time to Live in seconds for the request. This must be between 30 and 600.")]
+		public int? TTL { get; set; }
+
+		[Option('t', "title", HelpText = "[Directory Service Only] Title of the authorization request.")]
+		public string AuthTitle { get; set; }
+
+		[Option('h', "push-title", HelpText = "[Directory Service Only] Title of the push message for the authorization request.")]
+		public string PushTitle { get; set; }
+
+		[Option('b', "push-body", HelpText = "[Directory Service Only] Body of the push message for the authorization request.")]
+		public string PushBody { get; set; }
+
+		[Option('f', "fraud-denial-reasons", Default = 0, HelpText = "[Directory Service Only] The number of denial reasons flagged as fraud for the authorization request.")]
+		public int FraudDenialReasons { get; set; }
+
+		[Option('n', "non-fraud-denial-reasons", Default = 0, HelpText = "[Directory Service Only] The number of denial reasons not flagged as fraud for the authorization request.")]
+		public int NonFraudDenialReasons { get; set; }
+	}
+
+	[Verb("service-auth", HelpText = "Authorize a user against a service using a polling method")]
+	class ServiceAuthOptions : AuthOptions
+	{
+		// This left intentionally blank
 	}
 
 	[Verb("service-auth-webhook", HelpText = "Authorize a user against a service using the Webhook method.")]
-	class ServiceAuthWebhookOptions : ServiceOptions
+	class ServiceAuthWebhookOptions : AuthOptions
 	{
-		[Option('u', "username", HelpText = "The username to authorize", Required = true)]
-		public string Username { get; set; }
+		// This left intentionally blank
 	}
 
 	[Verb("service-session-start", HelpText = "Start a session for a user")]

--- a/src/iovation.LaunchKey.Sdk.Tests.Integration/SpecFlow/Contexts/DirectoryServiceClientContext.cs
+++ b/src/iovation.LaunchKey.Sdk.Tests.Integration/SpecFlow/Contexts/DirectoryServiceClientContext.cs
@@ -40,7 +40,7 @@ namespace iovation.LaunchKey.Sdk.Tests.Integration.SpecFlow.Contexts
 		public void Authorize(string userId, string context, AuthPolicy authPolicy)
 		{
 			GetServiceClientForCurrentService()
-				.Authorize(userId, context, authPolicy);
+				.CreateAuthorizationRequest(userId, context, authPolicy);
 		}
 
 		public void SessionStart(string userId, string requestId)

--- a/src/iovation.LaunchKey.Sdk.Tests/Transport/Domain/ServerSentEventAuthorizationResponseTests.cs
+++ b/src/iovation.LaunchKey.Sdk.Tests/Transport/Domain/ServerSentEventAuthorizationResponseTests.cs
@@ -27,7 +27,10 @@ namespace iovation.LaunchKey.Sdk.Tests.Transport.Domain
 				authorizationRequestId,
 				true,
 				"deviceId",
-				devicePins
+				devicePins,
+				"Type",
+				"Reason",
+				"Denial Reason"
 			);
 
 			Assert.AreSame(requestingEntity, o.RequestingEntity);
@@ -39,6 +42,9 @@ namespace iovation.LaunchKey.Sdk.Tests.Transport.Domain
 			Assert.AreEqual(true, o.Response);
 			Assert.AreEqual("deviceId", o.DeviceId);
 			Assert.AreSame(devicePins, o.DevicePins);
+			Assert.AreEqual("Type", o.Type);
+			Assert.AreEqual("Reason", o.Reason);
+			Assert.AreEqual("Denial Reason", o.DenialReason);
 		}
 	}
 }

--- a/src/iovation.LaunchKey.Sdk.Tests/Transport/Domain/ServiceV3AuthsGetResponseCoreTests.cs
+++ b/src/iovation.LaunchKey.Sdk.Tests/Transport/Domain/ServiceV3AuthsGetResponseCoreTests.cs
@@ -15,10 +15,11 @@ namespace iovation.LaunchKey.Sdk.Tests.Transport.Domain
 		[TestMethod]
 		public void ShouldDeserialize()
 		{
-			var json = "{\"public_key_id\": \"f7:93:a2:9e:45:ac:61:40:ef:33:22:58:52:d1:51:db\", \"service_user_hash\": \"B1R3RD7WFKjlr0g4RACl25c2phPqcunajeQeZdTkLkM\", \"user_push_id\": \"54631005-5987-5b88-b59e-62bac03cc155\", \"org_user_hash\": \"x3gBfvijAPJfKKL6arFDandXLvTx7ItFVgCGzEzWyBt\", \"auth\": \"i0uyoZ1XTlV3Qar9p1pcsITibCRNgpt252hT5kl0WXX9RMYwV44L10H3fV+6SYHm\\r\\nMp5LXqkozce+Cyxl7prR3nm+2ft/7wBCrvr+X6MN46v8HyUPFs+RK9uuic7Rwklz\\r\\nKS6WaL7yK7/ybN0SrqIb2wofj+WYvIxjVg6+/wZQbQLFkCzY9EZXKzHOC0dD/PnF\\r\\nZLNRbGuf8HoLbp4OOGxCmnH6Oj6svHfgJg7NFrciffRp/uWiW8yh5Xit3wWkmmOA\\r\\njF6DBpQiHizzVxLoDCO08l6gG2awkrddQRIKfDeLz5c397oMck1zMXzmDc03370R\\r\\nL0XrEWQWmsu1m9OR93CcsQ==\"}";
+			var json = "{\"public_key_id\": \"f7:93:a2:9e:45:ac:61:40:ef:33:22:58:52:d1:51:db\", \"service_user_hash\": \"B1R3RD7WFKjlr0g4RACl25c2phPqcunajeQeZdTkLkM\", \"user_push_id\": \"54631005-5987-5b88-b59e-62bac03cc155\", \"org_user_hash\": \"x3gBfvijAPJfKKL6arFDandXLvTx7ItFVgCGzEzWyBt\", \"auth\": \"i0uyoZ1XTlV3Qar9p1pcsITibCRNgpt252hT5kl0WXX9RMYwV44L10H3fV+6SYHm\\r\\nMp5LXqkozce+Cyxl7prR3nm+2ft/7wBCrvr+X6MN46v8HyUPFs+RK9uuic7Rwklz\\r\\nKS6WaL7yK7/ybN0SrqIb2wofj+WYvIxjVg6+/wZQbQLFkCzY9EZXKzHOC0dD/PnF\\r\\nZLNRbGuf8HoLbp4OOGxCmnH6Oj6svHfgJg7NFrciffRp/uWiW8yh5Xit3wWkmmOA\\r\\njF6DBpQiHizzVxLoDCO08l6gG2awkrddQRIKfDeLz5c397oMck1zMXzmDc03370R\\r\\nL0XrEWQWmsu1m9OR93CcsQ==\",\"auth_jwe\": \"eyJhbGciUlNBLU9BRVAiLCA.Ppd6dIfIelfqOrj3rkw.71BJymhM-QLBQAWA.t-4rGsoXt0.1DGC4k\"}";
 			var o = JsonConvert.DeserializeObject<ServiceV3AuthsGetResponseCore>(json);
 
 			Assert.AreEqual("i0uyoZ1XTlV3Qar9p1pcsITibCRNgpt252hT5kl0WXX9RMYwV44L10H3fV+6SYHm\r\nMp5LXqkozce+Cyxl7prR3nm+2ft/7wBCrvr+X6MN46v8HyUPFs+RK9uuic7Rwklz\r\nKS6WaL7yK7/ybN0SrqIb2wofj+WYvIxjVg6+/wZQbQLFkCzY9EZXKzHOC0dD/PnF\r\nZLNRbGuf8HoLbp4OOGxCmnH6Oj6svHfgJg7NFrciffRp/uWiW8yh5Xit3wWkmmOA\r\njF6DBpQiHizzVxLoDCO08l6gG2awkrddQRIKfDeLz5c397oMck1zMXzmDc03370R\r\nL0XrEWQWmsu1m9OR93CcsQ==", o.EncryptedDeviceResponse);
+			Assert.AreEqual("eyJhbGciUlNBLU9BRVAiLCA.Ppd6dIfIelfqOrj3rkw.71BJymhM-QLBQAWA.t-4rGsoXt0.1DGC4k", o.JweEncryptedDeviceResponse);
 			Assert.AreEqual("x3gBfvijAPJfKKL6arFDandXLvTx7ItFVgCGzEzWyBt", o.OrgUserHash);
 			Assert.AreEqual("f7:93:a2:9e:45:ac:61:40:ef:33:22:58:52:d1:51:db", o.PublicKeyId);
 			Assert.AreEqual("B1R3RD7WFKjlr0g4RACl25c2phPqcunajeQeZdTkLkM", o.ServiceUserHash);

--- a/src/iovation.LaunchKey.Sdk.Tests/Transport/Domain/ServiceV3AuthsGetResponseDeviceJWETests.cs
+++ b/src/iovation.LaunchKey.Sdk.Tests/Transport/Domain/ServiceV3AuthsGetResponseDeviceJWETests.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using iovation.LaunchKey.Sdk.Transport.Domain;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+
+namespace iovation.LaunchKey.Sdk.Tests.Transport.Domain
+{
+	[TestClass]
+	public class ServiceV3AuthsGetResponseDeviceJWETests
+	{
+		[TestMethod]
+		public void ShouldDeserialize()
+		{
+			var json = "{" +
+				"    \"type\": \"DENIED\"," +
+				"    \"reason\": \"FRAUDULENT\"," +
+				"    \"denial_reason\": \"DEN2\"," +
+				"    \"device_id\": \"5d1acf5c-dc5d-11e7-9ea1-0469f8dc10a5\"," +
+				"    \"service_pins\": [\"2648\", \"2046\", \"0583\", \"2963\", \"2046\"]," +
+				"    \"auth_request\": \"8c3c0268-f692-11e7-bd2e-7692096aba47\"" +
+				"}"; ;
+			var o = JsonConvert.DeserializeObject<ServiceV3AuthsGetResponseDeviceJWE>(json);
+
+			Assert.AreEqual("DENIED", o.Type);
+			Assert.AreEqual("FRAUDULENT", o.Reason);
+			Assert.AreEqual("DEN2", o.DenialReason);
+			Assert.AreEqual(Guid.Parse("8c3c0268-f692-11e7-bd2e-7692096aba47"), o.AuthorizationRequestId);
+			Assert.AreEqual("5d1acf5c-dc5d-11e7-9ea1-0469f8dc10a5", o.DeviceId);
+			Assert.AreEqual("2648", o.ServicePins[0]);
+			Assert.AreEqual("2046", o.ServicePins[1]);
+			Assert.AreEqual("0583", o.ServicePins[2]);
+			Assert.AreEqual("2963", o.ServicePins[3]);
+			Assert.AreEqual("2046", o.ServicePins[4]);
+		}
+	}
+}

--- a/src/iovation.LaunchKey.Sdk.Tests/Transport/Domain/ServiceV3AuthsGetResponseTests.cs
+++ b/src/iovation.LaunchKey.Sdk.Tests/Transport/Domain/ServiceV3AuthsGetResponseTests.cs
@@ -27,7 +27,10 @@ namespace iovation.LaunchKey.Sdk.Tests.Transport.Domain
 				authorizationRequestId,
 				true,
 				"deviceId",
-				devicePins
+				devicePins,
+				null,
+				null,
+				null
 			);
 
 			Assert.AreSame(requestingEntity, o.RequestingEntity);

--- a/src/iovation.LaunchKey.Sdk.Tests/Transport/Domain/ServiceV3AuthsPostRequestTests.cs
+++ b/src/iovation.LaunchKey.Sdk.Tests/Transport/Domain/ServiceV3AuthsPostRequestTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using iovation.LaunchKey.Sdk.Json;
 using iovation.LaunchKey.Sdk.Transport.Domain;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -12,7 +13,7 @@ namespace iovation.LaunchKey.Sdk.Tests.Transport.Domain
 		public void Constructor_ShouldSetProperties()
 		{
 			var authPolicy = new AuthPolicy(null, null, null, null, null, null);
-			var o = new ServiceV3AuthsPostRequest("un", authPolicy, "ctx", "title", 999, "Push Title", "Push Body");
+			var o = new ServiceV3AuthsPostRequest("un", authPolicy, "ctx", "title", 999, "Push Title", "Push Body", new List<DenialReason> { new DenialReason("1", "a", true) });
 
 			Assert.AreSame(o.AuthPolicy, authPolicy);
 			Assert.AreEqual(o.Context, "ctx");
@@ -21,13 +22,14 @@ namespace iovation.LaunchKey.Sdk.Tests.Transport.Domain
 			Assert.AreEqual(o.TTL, 999);
 			Assert.AreEqual(o.PushTitle, "Push Title");
 			Assert.AreEqual(o.PushBody, "Push Body");
+			Assert.AreEqual(o.DenialReasons[0], new DenialReason("1", "a", true));
 		}
 
 		[TestMethod]
 		public void ShouldSerializeCorrectly_JustUserId()
 		{
 			var encoder = new JsonNetJsonEncoder();
-			var o = new ServiceV3AuthsPostRequest("my-unique-user-identifier", null, null, null, null, null, null);
+			var o = new ServiceV3AuthsPostRequest("my-unique-user-identifier", null, null, null, null, null, null, null);
 			var json = encoder.EncodeObject(o);
 			Assert.AreEqual("{\"username\":\"my-unique-user-identifier\"}", json);
 		}
@@ -36,7 +38,7 @@ namespace iovation.LaunchKey.Sdk.Tests.Transport.Domain
 		public void ShouldSerializeCorrectly_WithContext()
 		{
 			var encoder = new JsonNetJsonEncoder();
-			var o = new ServiceV3AuthsPostRequest("my-unique-user-identifier", null, "Authorizing charge for $12.34 at iovation.com", null, null, null, null);
+			var o = new ServiceV3AuthsPostRequest("my-unique-user-identifier", null, "Authorizing charge for $12.34 at iovation.com", null, null, null, null, null);
 			var json = encoder.EncodeObject(o);
 			Assert.AreEqual("{\"username\":\"my-unique-user-identifier\",\"context\":\"Authorizing charge for $12.34 at iovation.com\"}", json);
 		}
@@ -45,7 +47,7 @@ namespace iovation.LaunchKey.Sdk.Tests.Transport.Domain
 		public void ShouldSerializeCorrectly_WithTitle()
 		{
 			var encoder = new JsonNetJsonEncoder();
-			var o = new ServiceV3AuthsPostRequest("my-unique-user-identifier", null, null, "Title", null, null, null);
+			var o = new ServiceV3AuthsPostRequest("my-unique-user-identifier", null, null, "Title", null, null, null, null);
 			var json = encoder.EncodeObject(o);
 			Assert.AreEqual("{\"username\":\"my-unique-user-identifier\",\"title\":\"Title\"}", json);
 		}
@@ -54,7 +56,7 @@ namespace iovation.LaunchKey.Sdk.Tests.Transport.Domain
 		public void ShouldSerializeCorrectly_WithTTL()
 		{
 			var encoder = new JsonNetJsonEncoder();
-			var o = new ServiceV3AuthsPostRequest("my-unique-user-identifier", null, null, null, 999, null, null);
+			var o = new ServiceV3AuthsPostRequest("my-unique-user-identifier", null, null, null, 999, null, null, null);
 			var json = encoder.EncodeObject(o);
 			Assert.AreEqual("{\"username\":\"my-unique-user-identifier\",\"ttl\":999}", json);
 		}
@@ -74,7 +76,7 @@ namespace iovation.LaunchKey.Sdk.Tests.Transport.Domain
 					}
 				}
 			);
-			var o = new ServiceV3AuthsPostRequest("my-unique-user-identifier", policy, null, null, null, null, null);
+			var o = new ServiceV3AuthsPostRequest("my-unique-user-identifier", policy, null, null, null, null, null, null);
 			var json = encoder.EncodeObject(o);
 			var expected = "{\"username\":\"my-unique-user-identifier\",\"policy\":{\"minimum_requirements\":[{\"requirement\":\"authenticated\",\"any\":2}],\"factors\":[{\"factor\":\"geofence\",\"requirement\":\"forced requirement\",\"priority\":1,\"attributes\":{\"locations\":[{\"radius\":60.0,\"latitude\":27.175,\"longitude\":78.0422}]}}]}}";
 
@@ -85,7 +87,7 @@ namespace iovation.LaunchKey.Sdk.Tests.Transport.Domain
 		public void ShouldSerializeCorrectly_WithPushTitle()
 		{
 			var encoder = new JsonNetJsonEncoder();
-			var o = new ServiceV3AuthsPostRequest("my-unique-user-identifier", null, null, null, null, "Push Title", null);
+			var o = new ServiceV3AuthsPostRequest("my-unique-user-identifier", null, null, null, null, "Push Title", null, null);
 			var json = encoder.EncodeObject(o);
 			Assert.AreEqual("{\"username\":\"my-unique-user-identifier\",\"push_title\":\"Push Title\"}", json);
 		}
@@ -94,9 +96,19 @@ namespace iovation.LaunchKey.Sdk.Tests.Transport.Domain
 		public void ShouldSerializeCorrectly_WithPushBody()
 		{
 			var encoder = new JsonNetJsonEncoder();
-			var o = new ServiceV3AuthsPostRequest("my-unique-user-identifier", null, null, null, null, null, "Push Body");
+			var o = new ServiceV3AuthsPostRequest("my-unique-user-identifier", null, null, null, null, null, "Push Body", null);
 			var json = encoder.EncodeObject(o);
 			Assert.AreEqual("{\"username\":\"my-unique-user-identifier\",\"push_body\":\"Push Body\"}", json);
+		}
+
+		[TestMethod]
+		public void ShouldSerializeCorrectly_WithDenialReasons()
+		{
+			var encoder = new JsonNetJsonEncoder();
+			var denialReasons = new List<DenialReason> { new DenialReason("1", "Reason 1", true), new DenialReason("2", "Reason 2", false) };
+			var o = new ServiceV3AuthsPostRequest("my-unique-user-identifier", null, null, null, null, null, null, denialReasons);
+			var json = encoder.EncodeObject(o);
+			Assert.AreEqual("{\"username\":\"my-unique-user-identifier\",\"denial_reasons\":[{\"id\":\"1\",\"reason\":\"Reason 1\",\"fraud\":true},{\"id\":\"2\",\"reason\":\"Reason 2\",\"fraud\":false}]}", json);
 		}
 	}
 }

--- a/src/iovation.LaunchKey.Sdk.Tests/Transport/WebClient/WebClientTransportTests.cs
+++ b/src/iovation.LaunchKey.Sdk.Tests/Transport/WebClient/WebClientTransportTests.cs
@@ -130,7 +130,7 @@ PmRoieUCtxxvmnckMGk4ub+/X4AJHb0ErqavEbIrrBNLW4ahtrJC5g==
 		{
 			// setup
 			var transport = GetTransport(GetBadNetworkHttpClient().Object);
-			var request = new ServiceV3AuthsPostRequest(null, null, null, null, null, null, null);
+			var request = new ServiceV3AuthsPostRequest(null, null, null, null, null, null, null, null);
 			var id = Guid.NewGuid();
 			var entity = new EntityIdentifier(EntityType.Service, id);
 
@@ -441,44 +441,12 @@ PmRoieUCtxxvmnckMGk4ub+/X4AJHb0ErqavEbIrrBNLW4ahtrJC5g==
 		private readonly Guid DefaultDeviceId = new Guid("00000000-0000-0000-0000-000000000004");
 
 		[TestMethod]
-		public void ServiceV3AuthsGet_ShouldReturnNullIfPending()
-		{
-			var httpClientMock = MakeMockHttpClient(responseCode: 204);
-			var httpClient = httpClientMock.Object;
-			var transport = MakeMockedTransport(httpClient, MakeMockedJsonService().Object, 204);
-			var response = transport.ServiceV3AuthsGet(TestConsts.DefaultAuthenticationId, TestConsts.DefaultServiceEntity);
-
-			Assert.IsNull(response);
-		}
-		
-		[TestMethod]
-		[ExpectedException(typeof(AuthorizationRequestTimedOutError))]
-		public void ServiceV3AuthsGet_ShouldThrowIfTimedOut()
-		{
-			var httpClientMock = MakeMockHttpClient(responseCode: 408);
-			var httpClient = httpClientMock.Object;
-			var transport = MakeMockedTransport(httpClient, MakeMockedJsonService().Object, 408);
-			transport.ServiceV3AuthsGet(TestConsts.DefaultAuthenticationId, TestConsts.DefaultServiceEntity);
-		}
-
-
-		[TestMethod]
 		public void ServiceV3AuthsPost_ShouldCallApi()
 		{
 			DoApiCallTest(
-				t => t.ServiceV3AuthsPost(new ServiceV3AuthsPostRequest("john", null, null, null, null, null, null), DefaultSubject),
+				t => t.ServiceV3AuthsPost(new ServiceV3AuthsPostRequest("john", null, null, null, null, null, null, null), DefaultSubject),
 				HttpMethod.POST,
 				"/service/v3/auths"
-			);
-		}
-
-		[TestMethod]
-		public void ServiceV3AuthsGet_ShouldCallApi()
-		{
-			DoApiCallTest(
-				t => t.ServiceV3AuthsGet(DefaultAuthId, DefaultSubject),
-				HttpMethod.GET, 
-				"/service/v3/auths/"+DefaultAuthId
 			);
 		}
 

--- a/src/iovation.LaunchKey.Sdk/Client/BasicServiceClient.cs
+++ b/src/iovation.LaunchKey.Sdk/Client/BasicServiceClient.cs
@@ -7,6 +7,8 @@ using iovation.LaunchKey.Sdk.Error;
 using iovation.LaunchKey.Sdk.Transport;
 using iovation.LaunchKey.Sdk.Transport.Domain;
 using AuthPolicy = iovation.LaunchKey.Sdk.Domain.Service.AuthPolicy;
+using DenialReason = iovation.LaunchKey.Sdk.Domain.Service.DenialReason;
+using TransportDenialReason = iovation.LaunchKey.Sdk.Transport.Domain.DenialReason;
 
 namespace iovation.LaunchKey.Sdk.Client
 {
@@ -26,7 +28,7 @@ namespace iovation.LaunchKey.Sdk.Client
 			return CreateAuthorizationRequest(user, context, policy).Id;
 		}
 		
-		public AuthorizationRequest CreateAuthorizationRequest(string user, string context = null, AuthPolicy policy = null, string title = null, int? ttl = null, string pushTitle = null, string pushBody = null)
+		public AuthorizationRequest CreateAuthorizationRequest(string user, string context = null, AuthPolicy policy = null, string title = null, int? ttl = null, string pushTitle = null, string pushBody = null, IList<DenialReason> denialReasons = null)
 		{
 			Transport.Domain.AuthPolicy requestPolicy = null;
 			if (policy != null)
@@ -47,7 +49,20 @@ namespace iovation.LaunchKey.Sdk.Client
 					).ToList()
 				);
 			}
-			var request = new ServiceV3AuthsPostRequest(user, requestPolicy, context, title, ttl, pushTitle, pushBody);
+			List<TransportDenialReason> transportDenialReasons;
+			if (denialReasons == null)
+			{
+				transportDenialReasons = null;
+			}
+			else
+			{
+				transportDenialReasons = new List<TransportDenialReason>();
+				foreach (DenialReason dr in denialReasons)
+				{
+					transportDenialReasons.Add(new TransportDenialReason(dr.Id, dr.Reason, dr.Fraud));
+				}
+			}
+			var request = new ServiceV3AuthsPostRequest(user, requestPolicy, context, title, ttl, pushTitle, pushBody, transportDenialReasons);
 			var response = _transport.ServiceV3AuthsPost(request, _serviceId);
 			var authRequest = new AuthorizationRequest(response.AuthRequest.ToString("D"), response.PushPackage);
 			return authRequest;
@@ -59,6 +74,62 @@ namespace iovation.LaunchKey.Sdk.Client
 			var response = _transport.ServiceV3AuthsGet(Guid.Parse(authorizationRequestId), _serviceId);
 			if (response != null)
 			{
+				AuthorizationResponseType type;
+				if (response.Type == "AUTHORIZED")
+				{
+					type = AuthorizationResponseType.AUTHORIZED;
+				}
+				else if (response.Type == "DENIED")
+				{
+					type = AuthorizationResponseType.DENIED;
+				}
+				else if (response.Type == "FAILED")
+				{
+					type = AuthorizationResponseType.FAILED;
+				}
+				else
+				{
+					type = AuthorizationResponseType.OTHER;
+				}
+
+				AuthorizationResponseReason reason;
+				if (response.Reason == "APPROVED")
+				{
+					reason = AuthorizationResponseReason.APPROVED;
+				}
+				else if (response.Reason == "DISAPPROVED")
+				{
+					reason = AuthorizationResponseReason.DISAPPROVED;
+				}
+				else if (response.Reason == "FRAUDULENT")
+				{
+					reason = AuthorizationResponseReason.FRAUDULENT;
+				}
+				else if (response.Reason == "POLICY")
+				{
+					reason = AuthorizationResponseReason.POLICY;
+				}
+				else if (response.Reason == "PERMISSION")
+				{
+					reason = AuthorizationResponseReason.PERMISSION;
+				}
+				else if (response.Reason == "AUTHENTICATION")
+				{
+					reason = AuthorizationResponseReason.AUTHENTICATION;
+				}
+				else if (response.Reason == "CONFIGURATION")
+				{
+					reason = AuthorizationResponseReason.CONFIGURATION;
+				}
+				else if (response.Reason == "BUSY_LOCAL")
+				{
+					reason = AuthorizationResponseReason.BUSY_LOCAL;
+				}
+				else
+				{
+					reason = AuthorizationResponseReason.OTHER;
+				}
+
 				return new AuthorizationResponse(
 					response.AuthorizationRequestId.ToString("D"),
 					response.Response,
@@ -66,7 +137,11 @@ namespace iovation.LaunchKey.Sdk.Client
 					response.OrganizationUserHash,
 					response.UserPushId,
 					response.DeviceId,
-					new List<string>(response.DevicePins)
+					new List<string>(response.DevicePins),
+					type,
+					reason,
+					response.DenialReason,
+					reason == AuthorizationResponseReason.FRAUDULENT
 				);
 			}
 
@@ -100,6 +175,61 @@ namespace iovation.LaunchKey.Sdk.Client
 			if (serverSentEvent is ServerSentEventAuthorizationResponse)
 			{
 				var authEvent = (ServerSentEventAuthorizationResponse)serverSentEvent;
+				AuthorizationResponseType type;
+				if (authEvent.Type == "AUTHORIZED")
+				{
+					type = AuthorizationResponseType.AUTHORIZED;
+				}
+				else if (authEvent.Type == "DENIED")
+				{
+					type = AuthorizationResponseType.DENIED;
+				}
+				else if (authEvent.Type == "FAILED")
+				{
+					type = AuthorizationResponseType.FAILED;
+				}
+				else
+				{
+					type = AuthorizationResponseType.OTHER;
+				}
+
+				AuthorizationResponseReason reason;
+				if (authEvent.Reason == "APPROVED")
+				{
+					reason = AuthorizationResponseReason.APPROVED;
+				}
+				else if (authEvent.Reason == "DISAPPROVED")
+				{
+					reason = AuthorizationResponseReason.DISAPPROVED;
+				}
+				else if (authEvent.Reason == "FRAUDULENT")
+				{
+					reason = AuthorizationResponseReason.FRAUDULENT;
+				}
+				else if (authEvent.Reason == "POLICY")
+				{
+					reason = AuthorizationResponseReason.POLICY;
+				}
+				else if (authEvent.Reason == "PERMISSION")
+				{
+					reason = AuthorizationResponseReason.PERMISSION;
+				}
+				else if (authEvent.Reason == "AUTHENTICATION")
+				{
+					reason = AuthorizationResponseReason.AUTHENTICATION;
+				}
+				else if (authEvent.Reason == "CONFIGURATION")
+				{
+					reason = AuthorizationResponseReason.CONFIGURATION;
+				}
+				else if (authEvent.Reason == "BUSY_LOCAL")
+				{
+					reason = AuthorizationResponseReason.BUSY_LOCAL;
+				}
+				else
+				{
+					reason = AuthorizationResponseReason.OTHER;
+				}
 				return new AuthorizationResponseWebhookPackage(
 					new AuthorizationResponse(
 						authEvent.AuthorizationRequestId.ToString("D"),
@@ -108,7 +238,11 @@ namespace iovation.LaunchKey.Sdk.Client
 						authEvent.OrganizationUserHash,
 						authEvent.UserPushId,
 						authEvent.DeviceId,
-						authEvent.DevicePins.ToList()
+						authEvent.DevicePins.ToList(),
+						type,
+						reason,
+						authEvent.DenialReason,
+						reason == AuthorizationResponseReason.FRAUDULENT
 					)
 				);
 			}

--- a/src/iovation.LaunchKey.Sdk/Client/IServiceClient.cs
+++ b/src/iovation.LaunchKey.Sdk/Client/IServiceClient.cs
@@ -25,7 +25,7 @@ namespace iovation.LaunchKey.Sdk.Client
 		/// <param name="title">The title to display on the device during authorization request</param>
 		/// <param name="ttl">Time to live in seconds for the authorization request. If not provided or null, the system default will be used</param>
 		/// <returns>Information regarding the authorization request.</returns>
-		AuthorizationRequest CreateAuthorizationRequest(string user, string context = null, AuthPolicy policy = null, string title = null, int? ttl = null, string pushTitle = null, string pushBody = null);
+		AuthorizationRequest CreateAuthorizationRequest(string user, string context = null, AuthPolicy policy = null, string title = null, int? ttl = null, string pushTitle = null, string pushBody = null, IList<DenialReason> denialReasons = null);
 
 		/// <summary>
 		/// Retrieve the status of an authorization request.

--- a/src/iovation.LaunchKey.Sdk/Crypto/Jwt/JwtClaims.cs
+++ b/src/iovation.LaunchKey.Sdk/Crypto/Jwt/JwtClaims.cs
@@ -24,6 +24,8 @@ namespace iovation.LaunchKey.Sdk.Crypto.Jwt
 
 	public class JwtClaimsRequest
 	{
+		internal static object Object;
+
 		[JsonProperty("func")]
 		public string ContentHashAlgorithm { get; set; }
 

--- a/src/iovation.LaunchKey.Sdk/Domain/Service/AuthorizationResponse.cs
+++ b/src/iovation.LaunchKey.Sdk/Domain/Service/AuthorizationResponse.cs
@@ -46,7 +46,27 @@ namespace iovation.LaunchKey.Sdk.Domain.Service
 		/// </summary>
 		public List<string> DevicePins { get; }
 
-		public AuthorizationResponse(string authorizationRequestId, bool authorized, string serviceUserHash, string organizationUserHash, string userPushId, string deviceId, List<string> devicePins)
+		/// <summary>
+		/// The response type. This is a general categorization of the response.
+		/// </summary>
+		public AuthorizationResponseType? Type { get; }
+
+		/// <summary>
+		/// The reason for the response value.
+		/// </summary>
+		public AuthorizationResponseReason? Reason { get; }
+
+		/// <summary>
+		/// ID for DenialReason in list provided to createAuthorizationRequest which was selected by the user when denying the request.
+		/// </summary>
+		public string DenialReason { get; }
+
+		/// <summary>
+		/// Was the authorization request identified as fraudulent?
+		/// </summary>
+		public bool? Fraud { get; }
+
+		public AuthorizationResponse(string authorizationRequestId, bool authorized, string serviceUserHash, string organizationUserHash, string userPushId, string deviceId, List<string> devicePins, AuthorizationResponseType? type, AuthorizationResponseReason? reason, string denialReason, bool? fraud)
 		{
 			AuthorizationRequestId = authorizationRequestId;
 			Authorized = authorized;
@@ -55,6 +75,92 @@ namespace iovation.LaunchKey.Sdk.Domain.Service
 			UserPushId = userPushId;
 			DeviceId = deviceId;
 			DevicePins = devicePins;
+			Type = type;
+			Reason = reason;
+			DenialReason = denialReason;
+			Fraud = fraud;
 		}
+	}
+
+	/// <summary>
+	/// The response type. This is a general categorization of the response.
+	/// </summary>
+	public enum AuthorizationResponseType
+	{
+		/// <summary>
+		/// The user authorized the authorization request
+		/// </summary>
+		AUTHORIZED,
+
+		/// <summary>
+		/// The use denied the authorization request
+		/// </summary>
+		DENIED,
+
+		/// <summary>
+		/// The user failed to complete the authentication request
+		/// </summary>
+		FAILED,
+
+		/// <summary>
+		/// Other exists only to allow for forward compatibility to future response types
+		/// </summary>
+		OTHER
+	}
+
+	/// <summary>
+	/// The reason for the response value.
+	/// </summary>
+	public enum AuthorizationResponseReason
+	{
+		/// <summary>
+		/// User satisfies all request policy requirements; successfully authenticates with all applicable methods
+		/// </summary>
+		APPROVED,
+
+		/// <summary>
+		/// User satisfies all request policy requirements; chooses to deny request rather than proceed with
+		/// authentication
+		/// </summary>
+		DISAPPROVED,
+
+		/// <summary>
+		/// User satisfies all request policy requirements; chooses to deny request because they believe it to be
+		/// fraudulent in some manner
+		/// </summary>
+		FRAUDULENT,
+
+		/// <summary>
+		/// Authenticator fails to satisfy request policy; authentication not allowed
+		/// </summary>
+		POLICY,
+
+		/// <summary>
+		/// Authenticator satisfies all request policy requirements, but permission on device prevents auth method
+		/// verification
+		/// </summary>
+		PERMISSION,
+
+		/// <summary>
+		/// Authenticator satisfies all request policy requirements, but user fails to successfully authenticate with
+		/// all required authentication methods
+		/// </summary>
+		AUTHENTICATION,
+
+		/// <summary>
+		/// Authenticator fails to satisfy request policy because authenticator configuration is incompatible with the
+		/// request policy (i.e. requiring an auth method that is configured to be unavailable to end users)
+		/// </summary>
+		CONFIGURATION,
+
+		/// <summary>
+		/// User can't receive or respond to request because a Local Auth Request is pending authorization
+		/// </summary>
+		BUSY_LOCAL,
+
+		/// <summary>
+		/// Other exists only to allow for forward compatibility to future response reasons
+		/// </summary>
+		OTHER
 	}
 }

--- a/src/iovation.LaunchKey.Sdk/Domain/Service/DenialReason.cs
+++ b/src/iovation.LaunchKey.Sdk/Domain/Service/DenialReason.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace iovation.LaunchKey.Sdk.Domain.Service
+{
+	/// <summary>
+	/// Denial reason record. These are sent during an authorization request and presented to the
+	/// user to select from when they deny the request.
+	/// </summary>
+	public class DenialReason
+	{
+		public DenialReason(string id, string reason, bool fraud)
+		{
+			Id = id;
+			Reason = reason;
+			Fraud = fraud;
+		}
+
+		/// <summary>
+		/// ID of the reason
+		/// </summary>
+		public string Id { get; }
+
+		/// <summary>
+		/// Reason test for the reason
+		/// </summary>
+		public string Reason { get; }
+
+		/// <summary>
+		/// Is the reason fraud?
+		/// </summary>
+		public bool Fraud { get; }
+	}
+}

--- a/src/iovation.LaunchKey.Sdk/Transport/Domain/DenialReason.cs
+++ b/src/iovation.LaunchKey.Sdk/Transport/Domain/DenialReason.cs
@@ -1,0 +1,53 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+
+namespace iovation.LaunchKey.Sdk.Transport.Domain
+{
+	public class DenialReason : IEquatable<DenialReason>
+	{
+		public DenialReason(string id, string reason, bool fraud)
+		{
+			Id = id;
+			Reason = reason;
+			Fraud = fraud;
+		}
+
+		[JsonProperty("id")]
+		public string Id { get; }
+
+		[JsonProperty("reason")]
+		public string Reason { get; }
+
+		[JsonProperty("fraud")]
+		public bool Fraud { get; }
+
+		public bool Equals(DenialReason other)
+		{
+			return other != null &&
+				   Id == other.Id &&
+				   Reason == other.Reason &&
+				   Fraud == other.Fraud;
+		}
+
+		public override bool Equals(object obj)
+		{
+			var item = obj as DenialReason;
+			return Equals(item);
+		}
+
+		public override int GetHashCode()
+		{
+			var hashCode = -1513616286;
+			hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Id);
+			hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Reason);
+			hashCode = hashCode * -1521134295 + Fraud.GetHashCode();
+			return hashCode;
+		}
+
+		public override string ToString()
+		{
+			return $"Denialreason{{Id:\"{Id}\",Reason:\"{Reason}\",Fraud:{Fraud}}}";
+		}
+	}
+}

--- a/src/iovation.LaunchKey.Sdk/Transport/Domain/ServerSentEventAuthorizationResponse.cs
+++ b/src/iovation.LaunchKey.Sdk/Transport/Domain/ServerSentEventAuthorizationResponse.cs
@@ -4,8 +4,8 @@ namespace iovation.LaunchKey.Sdk.Transport.Domain
 {
 	public class ServerSentEventAuthorizationResponse : ServiceV3AuthsGetResponse, IServerSentEvent
 	{
-		public ServerSentEventAuthorizationResponse(EntityIdentifier requestingEntity, Guid serviceId, string serviceUserHash, string organizationUserHash, string userPushId, Guid authorizationRequestId, bool response, string deviceId, string[] devicePins)
-			: base(requestingEntity, serviceId, serviceUserHash, organizationUserHash, userPushId, authorizationRequestId, response, deviceId, devicePins)
+		public ServerSentEventAuthorizationResponse(EntityIdentifier requestingEntity, Guid serviceId, string serviceUserHash, string organizationUserHash, string userPushId, Guid authorizationRequestId, bool response, string deviceId, string[] devicePins, string type, string reason, string denialReason)
+			: base(requestingEntity, serviceId, serviceUserHash, organizationUserHash, userPushId, authorizationRequestId, response, deviceId, devicePins, type, reason, denialReason)
 		{
 		}
 	}

--- a/src/iovation.LaunchKey.Sdk/Transport/Domain/ServiceV3AuthsGetResponse.cs
+++ b/src/iovation.LaunchKey.Sdk/Transport/Domain/ServiceV3AuthsGetResponse.cs
@@ -13,7 +13,10 @@ namespace iovation.LaunchKey.Sdk.Transport.Domain
 			Guid authorizationRequestId,
 			bool response,
 			string deviceId,
-			string[] devicePins)
+			string[] devicePins,
+			string type,
+			string reason,
+			string denialReason)
 		{
 			RequestingEntity = requestingEntity;
 			ServiceId = serviceId;
@@ -24,6 +27,9 @@ namespace iovation.LaunchKey.Sdk.Transport.Domain
 			Response = response;
 			DeviceId = deviceId;
 			DevicePins = devicePins;
+			Type = type;
+			Reason = reason;
+			DenialReason = denialReason;
 		}
 
 		public EntityIdentifier RequestingEntity { get; }
@@ -35,5 +41,8 @@ namespace iovation.LaunchKey.Sdk.Transport.Domain
 		public bool Response { get; }
 		public string DeviceId { get; }
 		public string[] DevicePins { get; }
+		public string Type { get; }
+		public string Reason { get; }
+		public string DenialReason { get; }
 	}
 }

--- a/src/iovation.LaunchKey.Sdk/Transport/Domain/ServiceV3AuthsGetResponseCore.cs
+++ b/src/iovation.LaunchKey.Sdk/Transport/Domain/ServiceV3AuthsGetResponseCore.cs
@@ -4,6 +4,9 @@ namespace iovation.LaunchKey.Sdk.Transport.Domain
 {
 	public class ServiceV3AuthsGetResponseCore
 	{
+		[JsonProperty("auth_jwe")]
+		public string JweEncryptedDeviceResponse { get; set; }
+
 		[JsonProperty("auth", Required = Required.Always)]
 		public string EncryptedDeviceResponse { get; set; }
 

--- a/src/iovation.LaunchKey.Sdk/Transport/Domain/ServiceV3AuthsGetResponseDeviceJWE.cs
+++ b/src/iovation.LaunchKey.Sdk/Transport/Domain/ServiceV3AuthsGetResponseDeviceJWE.cs
@@ -1,0 +1,28 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace iovation.LaunchKey.Sdk.Transport.Domain
+{
+	public class ServiceV3AuthsGetResponseDeviceJWE
+	{
+		[JsonProperty("type")]
+		public string Type { get; set; }
+
+		[JsonProperty("reason")]
+		public string Reason { get; set; }
+
+		[JsonProperty("denial_reason")]
+		public string DenialReason { get; set; }
+
+		[JsonProperty("auth_request")]
+		public Guid AuthorizationRequestId { get; set; }
+
+		[JsonProperty("device_id")]
+		public string DeviceId { get; set; }
+
+		[JsonProperty("service_pins")]
+		public string[] ServicePins { get; set; }
+	}
+}

--- a/src/iovation.LaunchKey.Sdk/Transport/Domain/ServiceV3AuthsPostRequest.cs
+++ b/src/iovation.LaunchKey.Sdk/Transport/Domain/ServiceV3AuthsPostRequest.cs
@@ -1,4 +1,5 @@
 using Newtonsoft.Json;
+using System.Collections.Generic;
 
 namespace iovation.LaunchKey.Sdk.Transport.Domain
 {
@@ -25,7 +26,10 @@ namespace iovation.LaunchKey.Sdk.Transport.Domain
 		[JsonProperty("push_body")]
 		public string PushBody { get; }
 
-		public ServiceV3AuthsPostRequest(string username, AuthPolicy authPolicy, string context, string title, int? ttl, string pushTitle, string pushBody)
+		[JsonProperty("denial_reasons")]
+		public IList<DenialReason> DenialReasons { get; }
+
+		public ServiceV3AuthsPostRequest(string username, AuthPolicy authPolicy, string context, string title, int? ttl, string pushTitle, string pushBody, IList<DenialReason> denialReasons)
 		{
 			Username = username;
 			AuthPolicy = authPolicy;
@@ -34,6 +38,7 @@ namespace iovation.LaunchKey.Sdk.Transport.Domain
 			TTL = ttl;
 			PushTitle = pushTitle;
 			PushBody = pushBody;
+			DenialReasons = denialReasons;
 		}
 	}
 }


### PR DESCRIPTION
Added ability to set denial_context_inquiry_enabled on Directory in OrganizationClient.
Added ability to send Denial Reasons in Authorization Request via ServiceClient.
Added processing of Authorization Request responses to parse the new JWE encrypted device response that was necessary for adding more data to the response related to denial context.