### PR TITLE
fixed regression where cancel-auth in cli had duplicate parameters

### DIFF
--- a/src/iovation.LaunchKey.Sdk.ExampleCli/ProgramOptions.cs
+++ b/src/iovation.LaunchKey.Sdk.ExampleCli/ProgramOptions.cs
@@ -205,7 +205,7 @@ namespace iovation.LaunchKey.Sdk.ExampleCli
 	[Verb("service-auth-cancel", HelpText = "Cancel an existing authorization request for a user")]
 	class ServiceAuthCancelOptions : ServiceOptions
 	{
-		[Option('a', "auth-request", HelpText = "The ID of the authorization request you wish to cancel", Required = true)]
+		[Option('r', "auth-request", HelpText = "The ID of the authorization request you wish to cancel", Required = true)]
 		public string AuthRequestId { get; set; }
 	}
 


### PR DESCRIPTION
There was a regression with cancel-auth that happened because of work that was started on the device testing in and 3.4-DEV hadn't been merged to master yet and I messed up merging the code. LK-3820