### PR TITLE
.NET 6 Upgrade and .NET Framework 4.6.2 Minimum Support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,23 +7,19 @@ jobs:
   publish:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v1.1
     - name: Setup NuGet
-      uses: NuGet/setup-nuget@v1.0.5
+      uses: NuGet/setup-nuget@v1
     - name: Build SDK
       run: |
         dotnet restore src\iovation.LaunchKey.Sdk.sln
         msbuild "src\iovation.LaunchKey.Sdk\iovation.LaunchKey.Sdk.csproj" /m /verbosity:minimal /p:GeneratePackageOnBuild=false
+    - name: Run Tests
+      run: dotnet test -f net462 src/iovation.LaunchKey.Sdk.Tests
     - name: Package SDK
       run: |
         dotnet pack "src\iovation.LaunchKey.Sdk\iovation.LaunchKey.Sdk.csproj" --configuration Release
-        dotnet pack "src\iovation.LaunchKey.Sdk.ExampleCli\iovation.LaunchKey.Sdk.ExampleCli.csproj" --configuration Release
     - name: Publish SDK
-      uses: brandedoutcast/publish-nuget@v2.5.5
-      with:
-        PACKAGE_NAME: iovation.LaunchKey.Sdk
-        PROJECT_FILE_PATH: src/iovation.LaunchKey.Sdk/iovation.LaunchKey.Sdk.csproj
-        TAG_COMMIT: false
-        NUGET_KEY: ${{secrets.NUGET_API_KEY}}
+      run: nuget push **\*.nupkg -Source 'https://api.nuget.org/v3/index.json' -ApiKey ${{secrets.NUGET_API_KEY}} -NonInteractive

--- a/.github/workflows/test_dotnet_core_versions.yml
+++ b/.github/workflows/test_dotnet_core_versions.yml
@@ -19,48 +19,51 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        dotnet-version: ['2.1.x', '3.1.x', '5.0.x']
+        dotnet-version: ['6.0.x']
         os: ['ubuntu-latest', 'macos-latest']
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup .NET Core SDK ${{ matrix.dotnet-version }}
-      uses: actions/setup-dotnet@v1.7.2
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: ${{ matrix.dotnet-version }}
     - name: Build SDK
       run: |
-        dotnet build --framework netstandard20 src/iovation.LaunchKey.Sdk
-        dotnet build --framework netcoreapp21 src/iovation.LaunchKey.Sdk.Tests
+        dotnet build --framework net6.0 src/iovation.LaunchKey.Sdk
+        dotnet build --framework net6.0 src/iovation.LaunchKey.Sdk.Tests
+    - name: Run Tests
+      run: |
+        dotnet test --framework net6.0 src/iovation.LaunchKey.Sdk.Tests
   
   run_on_windows_dotnet_core:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v1.1
     - name: Setup NuGet
-      uses: NuGet/setup-nuget@v1.0.5
+      uses: NuGet/setup-nuget@v1
     - name: Restore NuGet Packages
       run: nuget restore src/iovation.LaunchKey.Sdk.sln
     - name: Setup dotnet
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: '2.1.x'
+        dotnet-version: '6.0.x'
     - name: Build SDK
       run: |
         msbuild src/iovation.LaunchKey.Sdk /p:Configuration=Release
         msbuild src/iovation.LaunchKey.Sdk.Tests /p:Configuration=Release
     - name: Run Tests
-      run: dotnet test -f netstandard20 src/iovation.LaunchKey.Sdk.Tests
+      run: dotnet test -f net6.0 src/iovation.LaunchKey.Sdk.Tests
 
   run_on_windows_dotnet_framework:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v1.1
     - name: Setup NuGet
-      uses: NuGet/setup-nuget@v1.0.5
+      uses: NuGet/setup-nuget@v1
     - name: Restore NuGet Packages
       run: nuget restore src/iovation.LaunchKey.Sdk.sln
     - name: Build SDK
@@ -68,4 +71,4 @@ jobs:
         msbuild src/iovation.LaunchKey.Sdk /p:Configuration=Release
         msbuild src/iovation.LaunchKey.Sdk.Tests /p:Configuration=Release
     - name: Run Tests
-      run: dotnet test -f net45 src/iovation.LaunchKey.Sdk.Tests
+      run: dotnet test -f net462 src/iovation.LaunchKey.Sdk.Tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 Change Log
 ----------
+5.0.0
+=====
+* Dropped support for everything below .NET 6 since .NET Core 2 and .NET Core 3 are EOL
+* Updated underlying httpclient to use HttpClient instead of WebRequest / WebResponse 
+
 4.1.1
 =====
 * Updated Newtonsoft.Json to remediate CWE-755: [handle improper handling of exceptional conditions](https://github.com/advisories/GHSA-5crp-9r3c-p9vr)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ Change Log
 5.0.0
 =====
 * Dropped support for everything below .NET 6 since .NET Core 2 and .NET Core 3 are EOL
-* Updated underlying httpclient to use HttpClient instead of WebRequest / WebResponse 
+* Dropped support for everything below .NET Framework 4.6.2
+* Added pragma compiler suppression for .NET 6 warning us to move to HttpClient instead of WebRequest / WebResponse because we have to support 
+  .NET Framework 4.6.2 and some of the API changes are not backported through Nuget packages 
 
 4.1.1
 =====

--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ This SDK is targeted toward:
 - Windows 7 and above
 - Linux
 - OSX
-- .NET Framework 4.5+
-- .NET Standard 2.0 (.NET 4.6.1+, .NET Core 2.0+, Mono 5.4, etc.) See .NET Standard compatibility here: https://docs.microsoft.com/en-us/dotnet/standard/net-standard
+- .NET Framework 4.6.2+
+- .NET Core (.NET 6)
 
 
 ## Building
-The solution file is for Visual Studio 2017, Visual Studio for Mac 2019, and the projects are multi-targeting .NET 4.5 and .NET Standard 2.0. The project should build out of the box. Simply clone, open in VS, compile.
+The solution file is for Visual Studio 2017, Visual Studio for Mac 2019, and the projects are multi-targeting .NET 4.6.2 and .NET 6. The project should build out of the box. Simply clone, open in VS, compile.
 
 This project also works with the JetBrains IDE Rider.  
 
@@ -28,7 +28,7 @@ cd iovation.LaunchKey.Sdk.Tests
 dotnet test
 ```
 
-This method results in both the .NET 4.0 and .NET Core runtimes being used for test execution. Currently, VS 2017's IDE-based test runner does *not* properly run all targets.
+This method results in both the .NET 4.6.2 and .NET Core runtimes being used for test execution. Currently, VS 2017's IDE-based test runner does *not* properly run all targets.
 
 If you are using Rider you can configure it to run for all runtimes
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 4.1.1.{build}
+version: 5.0.0.{build}
 
 image: Visual Studio 2017
 

--- a/src/iovation.LaunchKey.Sdk.ExampleCli/iovation.LaunchKey.Sdk.ExampleCli.csproj
+++ b/src/iovation.LaunchKey.Sdk.ExampleCli/iovation.LaunchKey.Sdk.ExampleCli.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp21</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Authors>iovation, Inc</Authors>
     <Company>iovation, Inc</Company>
     <Product>LaunchKey CLI Example</Product>

--- a/src/iovation.LaunchKey.Sdk.ExampleCli/iovation.LaunchKey.Sdk.ExampleCli.csproj
+++ b/src/iovation.LaunchKey.Sdk.ExampleCli/iovation.LaunchKey.Sdk.ExampleCli.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
     <Authors>iovation, Inc</Authors>
     <Company>iovation, Inc</Company>
     <Product>LaunchKey CLI Example</Product>
     <ReleaseVersion>4.1.1</ReleaseVersion>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/iovation.LaunchKey.Sdk.ExampleCli/iovation.LaunchKey.Sdk.ExampleCli.csproj
+++ b/src/iovation.LaunchKey.Sdk.ExampleCli/iovation.LaunchKey.Sdk.ExampleCli.csproj
@@ -5,7 +5,7 @@
     <Authors>iovation, Inc</Authors>
     <Company>iovation, Inc</Company>
     <Product>LaunchKey CLI Example</Product>
-    <ReleaseVersion>4.1.1</ReleaseVersion>
+    <ReleaseVersion>5.0.0</ReleaseVersion>
     <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 

--- a/src/iovation.LaunchKey.Sdk.Tests.Integration/iovation.LaunchKey.Sdk.Tests.Integration.csproj
+++ b/src/iovation.LaunchKey.Sdk.Tests.Integration/iovation.LaunchKey.Sdk.Tests.Integration.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
 
     <IsPackable>false</IsPackable>
-    <ReleaseVersion>4.1.1</ReleaseVersion>
+    <ReleaseVersion>5.0.0</ReleaseVersion>
     <TargetFrameworks>net462;net6.0</TargetFrameworks>
   </PropertyGroup>
 

--- a/src/iovation.LaunchKey.Sdk.Tests.Integration/iovation.LaunchKey.Sdk.Tests.Integration.csproj
+++ b/src/iovation.LaunchKey.Sdk.Tests.Integration/iovation.LaunchKey.Sdk.Tests.Integration.csproj
@@ -4,7 +4,7 @@
 
     <IsPackable>false</IsPackable>
     <ReleaseVersion>4.1.1</ReleaseVersion>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net462;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/iovation.LaunchKey.Sdk.Tests.Integration/iovation.LaunchKey.Sdk.Tests.Integration.csproj
+++ b/src/iovation.LaunchKey.Sdk.Tests.Integration/iovation.LaunchKey.Sdk.Tests.Integration.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp21;net461</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
     <ReleaseVersion>4.1.1</ReleaseVersion>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/iovation.LaunchKey.Sdk.Tests/Client/BasicServiceClientTests.cs
+++ b/src/iovation.LaunchKey.Sdk.Tests/Client/BasicServiceClientTests.cs
@@ -8,6 +8,8 @@ using iovation.LaunchKey.Sdk.Transport.Domain;
 using serviceDomain = iovation.LaunchKey.Sdk.Domain.Service;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+#pragma warning disable CS0618
+// Disable compiler warning on unit tests because until its completely obsolete you have to test the functionality isn't broken
 
 namespace iovation.LaunchKey.Sdk.Tests.Client
 {

--- a/src/iovation.LaunchKey.Sdk.Tests/iovation.LaunchKey.Sdk.Tests.csproj
+++ b/src/iovation.LaunchKey.Sdk.Tests/iovation.LaunchKey.Sdk.Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
 
     <IsPackable>false</IsPackable>
-    <ReleaseVersion>4.1.1</ReleaseVersion>
+    <ReleaseVersion>5.0.0</ReleaseVersion>
     <TargetFrameworks>net462;net6.0</TargetFrameworks>
   </PropertyGroup>
 

--- a/src/iovation.LaunchKey.Sdk.Tests/iovation.LaunchKey.Sdk.Tests.csproj
+++ b/src/iovation.LaunchKey.Sdk.Tests/iovation.LaunchKey.Sdk.Tests.csproj
@@ -4,7 +4,7 @@
 
     <IsPackable>false</IsPackable>
     <ReleaseVersion>4.1.1</ReleaseVersion>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net462;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/iovation.LaunchKey.Sdk.Tests/iovation.LaunchKey.Sdk.Tests.csproj
+++ b/src/iovation.LaunchKey.Sdk.Tests/iovation.LaunchKey.Sdk.Tests.csproj
@@ -1,18 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp21;net45</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
     <ReleaseVersion>4.1.1</ReleaseVersion>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="CompareNETObjects" Version="4.57.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Moq" Version="4.10.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/iovation.LaunchKey.Sdk.sln
+++ b/src/iovation.LaunchKey.Sdk.sln
@@ -11,6 +11,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\CHANGELOG.md = ..\CHANGELOG.md
 		..\DEPLOYING.md = ..\DEPLOYING.md
 		..\README.md = ..\README.md
+		..\.github\workflows\publish.yml = ..\.github\workflows\publish.yml
+		..\.github\workflows\test_dotnet_core_versions.yml = ..\.github\workflows\test_dotnet_core_versions.yml
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "iovation.LaunchKey.Sdk", "iovation.LaunchKey.Sdk\iovation.LaunchKey.Sdk.csproj", "{7429B6AD-791E-4953-A67A-D4CEB3E8C38B}"

--- a/src/iovation.LaunchKey.Sdk/Transport/WebClient/HttpClient.cs
+++ b/src/iovation.LaunchKey.Sdk/Transport/WebClient/HttpClient.cs
@@ -3,7 +3,11 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Reflection;
-
+#pragma warning disable SYSLIB0014
+/*
+ Disabling warning for .NET 6 because we have to support .NET Framework 4.6.2 and some of the changes are not
+ backported through the nuget package System.Net.Http at this time. 
+*/
 namespace iovation.LaunchKey.Sdk.Transport.WebClient
 {
     /// <summary>

--- a/src/iovation.LaunchKey.Sdk/iovation.LaunchKey.Sdk.csproj
+++ b/src/iovation.LaunchKey.Sdk/iovation.LaunchKey.Sdk.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard20;net45</TargetFrameworks>
     <AssemblyVersion>4.1.1.0</AssemblyVersion>
     <FileVersion>4.1.1.0</FileVersion>
     <Version>4.1.1.0</Version>
@@ -14,6 +13,7 @@
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <ReleaseVersion>4.1.1</ReleaseVersion>
     <PackageVersion>4.1.1.0</PackageVersion>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType></DebugType>

--- a/src/iovation.LaunchKey.Sdk/iovation.LaunchKey.Sdk.csproj
+++ b/src/iovation.LaunchKey.Sdk/iovation.LaunchKey.Sdk.csproj
@@ -7,6 +7,7 @@
     <PackageVersion>5.0.0.0</PackageVersion>
     <Authors>iovation, Inc</Authors>
     <Product>LaunchKey .NET SDK</Product>
+    <PackageId>iovation.LaunchKey.Sdk</PackageId>
     <PackageTags>LaunchKey Security Multi-Factor Two-Factor Authentication 2FA MFA</PackageTags>
     <Copyright>Copyright 2019 iovation, Inc.</Copyright>
     <Description>SDK for accessing LaunchKey V3 endpoints.</Description>

--- a/src/iovation.LaunchKey.Sdk/iovation.LaunchKey.Sdk.csproj
+++ b/src/iovation.LaunchKey.Sdk/iovation.LaunchKey.Sdk.csproj
@@ -13,7 +13,7 @@
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <ReleaseVersion>4.1.1</ReleaseVersion>
     <PackageVersion>4.1.1.0</PackageVersion>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net462;net6.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType></DebugType>

--- a/src/iovation.LaunchKey.Sdk/iovation.LaunchKey.Sdk.csproj
+++ b/src/iovation.LaunchKey.Sdk/iovation.LaunchKey.Sdk.csproj
@@ -1,8 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <AssemblyVersion>4.1.1.0</AssemblyVersion>
-    <FileVersion>4.1.1.0</FileVersion>
-    <Version>4.1.1.0</Version>
+    <AssemblyVersion>5.0.0.0</AssemblyVersion>
+    <FileVersion>5.0.0.0</FileVersion>
+    <Version>5.0.0.0</Version>
+    <ReleaseVersion>5.0.0.0</ReleaseVersion>
+    <PackageVersion>5.0.0.0</PackageVersion>
     <Authors>iovation, Inc</Authors>
     <Product>LaunchKey .NET SDK</Product>
     <PackageTags>LaunchKey Security Multi-Factor Two-Factor Authentication 2FA MFA</PackageTags>
@@ -11,8 +13,6 @@
     <PackageLicenseUrl>https://raw.githubusercontent.com/iovation/launchkey-dotnet/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://docs.launchkey.com/api/index.html</PackageProjectUrl>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <ReleaseVersion>4.1.1</ReleaseVersion>
-    <PackageVersion>4.1.1.0</PackageVersion>
     <TargetFrameworks>net462;net6.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">


### PR DESCRIPTION
- Dropped support for everything below .NET 6 since .NET Core 2 and .NET Core 3 are EOL
- Dropped support for everything below .NET Framework 4.6.2
- Added pragma compiler suppression for .NET 6 warning us to move to HttpClient instead of WebRequest / WebResponse because we have to support .NET Framework 4.6.2 and some of the API changes are not backported through Nuget packages